### PR TITLE
fix typeahead accessibility bug

### DIFF
--- a/lib/components/form_fields/food_type_ahead_form_field.dart
+++ b/lib/components/form_fields/food_type_ahead_form_field.dart
@@ -6,7 +6,8 @@ import 'package:form_builder_validators/form_builder_validators.dart';
 import 'package:untare/futures/future_api_cache_foods.dart';
 import 'package:untare/models/food.dart';
 
-Widget foodTypeAheadFormField(Food? food, GlobalKey<FormBuilderState> formBuilderKey, BuildContext context) {
+Widget foodTypeAheadFormField(Food? food,
+    GlobalKey<FormBuilderState> formBuilderKey, BuildContext context) {
   final foodTextController = TextEditingController();
   const fieldName = 'food';
 
@@ -16,6 +17,7 @@ Widget foodTypeAheadFormField(Food? food, GlobalKey<FormBuilderState> formBuilde
   }
 
   return FormBuilderTypeAhead<Food>(
+    ignoreAccessibleNavigation: true,
     name: fieldName,
     controller: foodTextController,
     initialValue: food,
@@ -23,9 +25,8 @@ Widget foodTypeAheadFormField(Food? food, GlobalKey<FormBuilderState> formBuilde
     decoration: InputDecoration(
       labelText: AppLocalizations.of(context)!.food,
     ),
-    validator: FormBuilderValidators.compose([
-      FormBuilderValidators.required()
-    ]),
+    validator:
+        FormBuilderValidators.compose([FormBuilderValidators.required()]),
     itemBuilder: (context, food) {
       return ListTile(title: Text(food.name));
     },
@@ -42,7 +43,8 @@ Widget foodTypeAheadFormField(Food? food, GlobalKey<FormBuilderState> formBuilde
     },
     onSuggestionSelected: (suggestion) {
       foodTextController.text = suggestion.name;
-      formBuilderKey.currentState?.fields['category']?.didChange(suggestion.supermarketCategory);
+      formBuilderKey.currentState?.fields['category']
+          ?.didChange(suggestion.supermarketCategory);
     },
     onSaved: (Food? formFood) {
       Food? newFood = food;
@@ -53,7 +55,8 @@ Widget foodTypeAheadFormField(Food? food, GlobalKey<FormBuilderState> formBuilde
       } else {
         // Overwrite food, if changed in form
         if (food != null && formFood != null) {
-          if (food.id != formFood.id || (food.id == null && formFood.id == null)) {
+          if (food.id != formFood.id ||
+              (food.id == null && formFood.id == null)) {
             newFood = Food(
                 id: formFood.id,
                 name: formFood.name,
@@ -61,8 +64,7 @@ Widget foodTypeAheadFormField(Food? food, GlobalKey<FormBuilderState> formBuilde
                 onHand: formFood.onHand,
                 supermarketCategory: formFood.supermarketCategory,
                 recipeCount: formFood.recipeCount,
-                pluralName: formFood.pluralName
-            );
+                pluralName: formFood.pluralName);
           }
         } else if (formFood == null) {
           if (foodTextController.text != '') {
@@ -79,8 +81,7 @@ Widget foodTypeAheadFormField(Food? food, GlobalKey<FormBuilderState> formBuilde
               onHand: formFood.onHand,
               supermarketCategory: formFood.supermarketCategory,
               recipeCount: formFood.recipeCount,
-              pluralName: formFood.pluralName
-          );
+              pluralName: formFood.pluralName);
         }
 
         formBuilderKey.currentState!.fields[fieldName]!.didChange(newFood);

--- a/lib/components/form_fields/meal_type_type_ahead_form_field.dart
+++ b/lib/components/form_fields/meal_type_type_ahead_form_field.dart
@@ -6,14 +6,16 @@ import 'package:form_builder_validators/form_builder_validators.dart';
 import 'package:untare/futures/future_api_cache_meal_types.dart';
 import 'package:untare/models/meal_type.dart';
 
-Widget mealTypeTypeAheadFieldForm(MealType? mealType, GlobalKey<FormBuilderState> formBuilderKey, BuildContext context) {
+Widget mealTypeTypeAheadFieldForm(MealType? mealType,
+    GlobalKey<FormBuilderState> formBuilderKey, BuildContext context) {
   final mealTypeTextController = TextEditingController();
 
   if (mealType != null) {
     mealTypeTextController.text = mealType.name;
   }
-  
+
   return FormBuilderTypeAhead<MealType>(
+    ignoreAccessibleNavigation: true,
     name: 'mealType',
     initialValue: mealType,
     controller: mealTypeTextController,
@@ -21,9 +23,8 @@ Widget mealTypeTypeAheadFieldForm(MealType? mealType, GlobalKey<FormBuilderState
     decoration: InputDecoration(
       labelText: AppLocalizations.of(context)!.mealType,
     ),
-    validator: FormBuilderValidators.compose([
-      FormBuilderValidators.required()
-    ]),
+    validator:
+        FormBuilderValidators.compose([FormBuilderValidators.required()]),
     itemBuilder: (context, mealType) {
       return ListTile(title: Text(mealType.name));
     },
@@ -39,11 +40,14 @@ Widget mealTypeTypeAheadFieldForm(MealType? mealType, GlobalKey<FormBuilderState
 
       bool hideOnEqual = false;
       for (var element in mealTypeList) {
-        (element.name.toLowerCase() == query.toLowerCase()) ? hideOnEqual = true : null;
+        (element.name.toLowerCase() == query.toLowerCase())
+            ? hideOnEqual = true
+            : null;
       }
 
       if (query != '' && (mealTypeListByQuery.isEmpty || !hideOnEqual)) {
-        mealTypeListByQuery.add(MealType(name: query, defaultType: false, order: 0, createdBy: 1));
+        mealTypeListByQuery.add(
+            MealType(name: query, defaultType: false, order: 0, createdBy: 1));
       }
 
       return mealTypeListByQuery;
@@ -60,18 +64,33 @@ Widget mealTypeTypeAheadFieldForm(MealType? mealType, GlobalKey<FormBuilderState
       } else {
         // Overwrite meal type, if changed in form
         if (mealType != null && formMealType != null) {
-          if (mealType.id != formMealType.id || (mealType.id == null && formMealType.id == null)) {
-            newMealType = MealType(id: formMealType.id, name: formMealType.name, defaultType: formMealType.defaultType, order: formMealType.order, createdBy: formMealType.createdBy);
+          if (mealType.id != formMealType.id ||
+              (mealType.id == null && formMealType.id == null)) {
+            newMealType = MealType(
+                id: formMealType.id,
+                name: formMealType.name,
+                defaultType: formMealType.defaultType,
+                order: formMealType.order,
+                createdBy: formMealType.createdBy);
           }
-        } else if (formMealType== null) {
+        } else if (formMealType == null) {
           if (mealTypeTextController.text != '') {
-            newMealType = MealType(name: mealTypeTextController.text, order: 0, defaultType: false, createdBy: 1);
+            newMealType = MealType(
+                name: mealTypeTextController.text,
+                order: 0,
+                defaultType: false,
+                createdBy: 1);
           } else {
             newMealType = null;
             mealTypeTextController.text = '';
           }
         } else if (mealType == null) {
-          newMealType = MealType(id: formMealType.id, name: formMealType.name, defaultType: formMealType.defaultType, order: formMealType.order, createdBy: formMealType.createdBy);
+          newMealType = MealType(
+              id: formMealType.id,
+              name: formMealType.name,
+              defaultType: formMealType.defaultType,
+              order: formMealType.order,
+              createdBy: formMealType.createdBy);
         }
 
         formBuilderKey.currentState!.fields['mealType']!.didChange(newMealType);

--- a/lib/components/form_fields/recipe_type_ahead_form_field.dart
+++ b/lib/components/form_fields/recipe_type_ahead_form_field.dart
@@ -9,7 +9,9 @@ import 'package:untare/components/recipes/recipe_time_component.dart';
 import 'package:untare/futures/future_api_cache_recipes.dart';
 import 'package:untare/models/recipe.dart';
 
-Widget recipeTypeAheadFormField(Recipe? recipe, GlobalKey<FormBuilderState> formBuilderKey, BuildContext context, {String? referer}) {
+Widget recipeTypeAheadFormField(Recipe? recipe,
+    GlobalKey<FormBuilderState> formBuilderKey, BuildContext context,
+    {String? referer}) {
   final recipeTextController = TextEditingController();
 
   if (recipe != null) {
@@ -17,14 +19,14 @@ Widget recipeTypeAheadFormField(Recipe? recipe, GlobalKey<FormBuilderState> form
   }
 
   return FormBuilderTypeAhead<Recipe>(
+    ignoreAccessibleNavigation: true,
     name: 'recipe',
     controller: recipeTextController,
     initialValue: recipe,
     enabled: (referer == 'meal-plan' || referer == 'edit'),
     selectionToTextTransformer: (recipe) => recipe.name,
-    decoration: InputDecoration(
-      labelText: AppLocalizations.of(context)!.recipe
-    ),
+    decoration:
+        InputDecoration(labelText: AppLocalizations.of(context)!.recipe),
     validator: FormBuilderValidators.compose([
       if (referer != 'meal-plan' && referer != 'edit')
         FormBuilderValidators.required()
@@ -46,7 +48,8 @@ Widget recipeTypeAheadFormField(Recipe? recipe, GlobalKey<FormBuilderState> form
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               Text(recipe.name),
-              if (recipe.lastCooked != null || (recipe.rating != null && recipe.rating! > 0))
+              if (recipe.lastCooked != null ||
+                  (recipe.rating != null && recipe.rating! > 0))
                 Row(
                   children: [
                     Row(
@@ -59,8 +62,7 @@ Widget recipeTypeAheadFormField(Recipe? recipe, GlobalKey<FormBuilderState> form
                 )
             ],
           ),
-          trailing: buildRecipeTime(recipe)
-      );
+          trailing: buildRecipeTime(recipe));
     },
     suggestionsCallback: (query) async {
       return await getRecipesFromApiCache(query);
@@ -69,8 +71,10 @@ Widget recipeTypeAheadFormField(Recipe? recipe, GlobalKey<FormBuilderState> form
       recipeTextController.text = suggestion.name;
     },
     onChanged: (Recipe? recipe) {
-      if (formBuilderKey.currentState!.fields['servings'] != null && recipe != null) {
-        formBuilderKey.currentState!.fields['servings']!.didChange(recipe.servings.toString());
+      if (formBuilderKey.currentState!.fields['servings'] != null &&
+          recipe != null) {
+        formBuilderKey.currentState!.fields['servings']!
+            .didChange(recipe.servings.toString());
       }
     },
     onSaved: (Recipe? formRecipe) {

--- a/lib/components/form_fields/supermarket_category_type_ahead_form_field.dart
+++ b/lib/components/form_fields/supermarket_category_type_ahead_form_field.dart
@@ -5,26 +5,30 @@ import 'package:form_builder_extra_fields/form_builder_extra_fields.dart';
 import 'package:untare/futures/future_api_cache_supermarket_categories.dart';
 import 'package:untare/models/supermarket_category.dart';
 
-Widget supermarketCategoryTypeAheadFormField(SupermarketCategory? supermarketCategory, GlobalKey<FormBuilderState> formBuilderKey, BuildContext context) {
+Widget supermarketCategoryTypeAheadFormField(
+    SupermarketCategory? supermarketCategory,
+    GlobalKey<FormBuilderState> formBuilderKey,
+    BuildContext context) {
   final categoryTextController = TextEditingController();
 
   if (supermarketCategory != null) {
     categoryTextController.text = supermarketCategory.name;
   }
-  
+
   return FormBuilderTypeAhead<SupermarketCategory>(
+    ignoreAccessibleNavigation: true,
     name: 'category',
     controller: categoryTextController,
     initialValue: supermarketCategory,
     selectionToTextTransformer: (category) => category.name,
-    decoration: InputDecoration(
-      labelText: AppLocalizations.of(context)!.category
-    ),
+    decoration:
+        InputDecoration(labelText: AppLocalizations.of(context)!.category),
     itemBuilder: (context, category) {
       return ListTile(title: Text(category.name));
     },
     suggestionsCallback: (query) async {
-      List<SupermarketCategory> superMarketCategories = await getSupermarketCategoriesFromApiCache();
+      List<SupermarketCategory> superMarketCategories =
+          await getSupermarketCategoriesFromApiCache();
 
       List<SupermarketCategory> supermarketCategoriesByQuery = [];
       for (var element in superMarketCategories) {
@@ -35,10 +39,13 @@ Widget supermarketCategoryTypeAheadFormField(SupermarketCategory? supermarketCat
 
       bool hideOnEqual = false;
       for (var element in superMarketCategories) {
-        (element.name.toLowerCase() == query.toLowerCase()) ? hideOnEqual = true : null;
+        (element.name.toLowerCase() == query.toLowerCase())
+            ? hideOnEqual = true
+            : null;
       }
 
-      if (query != '' && (supermarketCategoriesByQuery.isEmpty || !hideOnEqual)) {
+      if (query != '' &&
+          (supermarketCategoriesByQuery.isEmpty || !hideOnEqual)) {
         supermarketCategoriesByQuery.add(SupermarketCategory(name: query));
       }
 
@@ -49,25 +56,33 @@ Widget supermarketCategoryTypeAheadFormField(SupermarketCategory? supermarketCat
     },
     onSaved: (SupermarketCategory? formCategory) {
       SupermarketCategory? newCategory = supermarketCategory;
-      
+
       // Invalidate empty string because type ahead field isn't aware
       if (categoryTextController.text.isEmpty) {
         formBuilderKey.currentState!.fields['category']!.didChange(null);
       } else {
         // Overwrite category, if changed in form
         if (supermarketCategory != null && formCategory != null) {
-          if (supermarketCategory.id != formCategory.id || (supermarketCategory.id == null && formCategory.id == null)) {
-            newCategory = SupermarketCategory(id: formCategory.id, name: formCategory.name, description: formCategory.description);
+          if (supermarketCategory.id != formCategory.id ||
+              (supermarketCategory.id == null && formCategory.id == null)) {
+            newCategory = SupermarketCategory(
+                id: formCategory.id,
+                name: formCategory.name,
+                description: formCategory.description);
           }
-        } else if (formCategory== null) {
+        } else if (formCategory == null) {
           if (categoryTextController.text != '') {
-            newCategory = SupermarketCategory(name: categoryTextController.text);
+            newCategory =
+                SupermarketCategory(name: categoryTextController.text);
           } else {
             newCategory = null;
             categoryTextController.text = '';
           }
         } else if (supermarketCategory == null) {
-          newCategory = SupermarketCategory(id: formCategory.id, name: formCategory.name, description: formCategory.description);
+          newCategory = SupermarketCategory(
+              id: formCategory.id,
+              name: formCategory.name,
+              description: formCategory.description);
         }
 
         formBuilderKey.currentState!.fields['category']!.didChange(newCategory);

--- a/lib/components/form_fields/unit_type_ahead_form_field.dart
+++ b/lib/components/form_fields/unit_type_ahead_form_field.dart
@@ -5,7 +5,8 @@ import 'package:form_builder_extra_fields/form_builder_extra_fields.dart';
 import 'package:untare/futures/future_api_cache_units.dart';
 import 'package:untare/models/unit.dart';
 
-Widget unitTypeAheadFormField(Unit? unit, GlobalKey<FormBuilderState> formBuilderKey, BuildContext context) {
+Widget unitTypeAheadFormField(Unit? unit,
+    GlobalKey<FormBuilderState> formBuilderKey, BuildContext context) {
   final unitTextController = TextEditingController();
   const fieldName = 'unit';
 
@@ -13,15 +14,14 @@ Widget unitTypeAheadFormField(Unit? unit, GlobalKey<FormBuilderState> formBuilde
   if (unit != null) {
     unitTextController.text = unit.name;
   }
-  
+
   return FormBuilderTypeAhead<Unit>(
+    ignoreAccessibleNavigation: true,
     name: fieldName,
     controller: unitTextController,
     initialValue: unit,
     selectionToTextTransformer: (unit) => unit.name,
-    decoration: InputDecoration(
-      labelText: AppLocalizations.of(context)!.unit
-    ),
+    decoration: InputDecoration(labelText: AppLocalizations.of(context)!.unit),
     itemBuilder: (context, unit) {
       return ListTile(title: Text(unit.name));
     },
@@ -41,17 +41,21 @@ Widget unitTypeAheadFormField(Unit? unit, GlobalKey<FormBuilderState> formBuilde
     },
     onSaved: (Unit? formUnit) {
       Unit? newUnit = unit;
-      
+
       if (unitTextController.text.isEmpty) {
         // Invalidate empty string because type ahead field isn't aware
         formBuilderKey.currentState!.fields[fieldName]!.didChange(null);
       } else {
         // Overwrite unit, if changed in form
         if (unit != null && formUnit != null) {
-          if (unit.id != formUnit.id || (unit.id == null && formUnit.id == null)) {
-            newUnit = Unit(id: formUnit.id, name: formUnit.name, description: formUnit.description);
+          if (unit.id != formUnit.id ||
+              (unit.id == null && formUnit.id == null)) {
+            newUnit = Unit(
+                id: formUnit.id,
+                name: formUnit.name,
+                description: formUnit.description);
           }
-        } else if (formUnit== null) {
+        } else if (formUnit == null) {
           if (unitTextController.text != '') {
             newUnit = Unit(name: unitTextController.text);
           } else {
@@ -59,7 +63,10 @@ Widget unitTypeAheadFormField(Unit? unit, GlobalKey<FormBuilderState> formBuilde
             unitTextController.text = '';
           }
         } else if (unit == null) {
-          newUnit = Unit(id: formUnit.id, name: formUnit.name, description: formUnit.description);
+          newUnit = Unit(
+              id: formUnit.id,
+              name: formUnit.name,
+              description: formUnit.description);
         }
 
         formBuilderKey.currentState!.fields[fieldName]!.didChange(newUnit);


### PR DESCRIPTION
Added the option `ignoreAccessibleNavigation=true` to every `FormBuilderTypeAhead` instance to bypass a bug with accessibility features.
The library [form_builder_extra_fields](https://github.com/flutter-form-builder-ecosystem/form_builder_extra_fields/pull/94) still uses the outdated library flutter_typeahead v4.8.0. This should be upgraded to [v5.0.1](https://github.com/flutter-form-builder-ecosystem/form_builder_extra_fields/pull/94). But there are [major breaking changes](https://pub.dev/packages/flutter_typeahead/changelog#500---2023-11-25). If the flutter_typeahead dependency is upgraded, then maybe this change can be reverted.
Reference: https://github.com/AbdulRahmanAlHamali/flutter_typeahead/issues/463
