### PR TITLE
Build debug android app to different application id

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -57,6 +57,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            applicationIdSuffix ".debug"
+        }
         release {
             minifyEnabled true
             shrinkResources true

--- a/android/app/src/debug/res/values/strings.xml
+++ b/android/app/src/debug/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name" translatable="false">Untare Debug</string>
+</resources>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
         </intent>
     </queries>
     <application
-        android:label="Untare"
+        android:label="@string/app_name"
         android:icon="@mipmap/app_icon">
         <activity
             android:name=".MainActivity"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name" translatable="false">Untare</string>
+</resources>


### PR DESCRIPTION
This PR changes the android build so that a debug apk has an added `debug` suffix to the application id.
This allows both the release as well as the debug application to be installed on a device simultaneously, easing testing on a personal device which has the release version installed.

Furthermore, this PR changes the application name for a debug build to `Untare Debug`